### PR TITLE
Fix to pythonas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage.xml
 *.vcxproj.filters
 *.userprefs
 *.DotSettings.user
+.runsettings
 
 # Build results
 [Bb]in/

--- a/README.rst
+++ b/README.rst
@@ -3,5 +3,7 @@ Ansys fork of `pythonnet <https://github.com/pythonnet/pythonnet>`_.
 We will try to keep this up-to-date with pythonnet and upstream changes that might benefit the pythonnet community
 
 Changes relative to pythonnet:
-- Revert of `#1240 <https://github.com/pythonnet/pythonnet/pull/1240>`_.
-- Enum REPR `#2239 <https://github.com/pythonnet/pythonnet/pull/2239>` is included in this release of version 3.0.2, but is unreleased in pythonnet
+
+* Revert of `#1240 <https://github.com/pythonnet/pythonnet/pull/1240>`_.
+* Enum REPR `#2239 <https://github.com/pythonnet/pythonnet/pull/2239>` is included in this release of version 3.0.2, but is unreleased in pythonnet
+* Opt-into explicit interface wrapping, `#19 <https://github.com/ansys/ansys-pythonnet/pull/19>`. This opts into the behavior that became the default in #1240 if ToPythonAs<T> is explicitly used

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -117,7 +117,9 @@ namespace Python.Runtime
 
         internal static NewReference ToPythonDetectType(object? value)
             => value is null ? new NewReference(Runtime.PyNone) : ToPython(value, value.GetType());
-        internal static NewReference ToPython(object? value, Type type)
+
+
+        internal static NewReference ToPython(object? value, Type type, bool wrapInterface = false)
         {
             if (value is PyObject pyObj)
             {
@@ -142,6 +144,12 @@ namespace Python.Runtime
             if (type.IsArray || type.IsEnum)
             {
                 return CLRObject.GetReference(value, type);
+            }
+
+            if (wrapInterface && type.IsInterface)
+            {
+                var ifaceObj = (InterfaceObject)ClassManager.GetClassImpl(type);
+                return ifaceObj.TryWrapObject(value);
             }
 
             // it the type is a python subclass of a managed type then return the
@@ -979,7 +987,7 @@ namespace Python.Runtime
         public static PyObject ToPythonAs<T>(this T? o)
         {
             if (o is null) return Runtime.None;
-            return Converter.ToPython(o, typeof(T)).MoveToPyObject();
+            return Converter.ToPython(o, typeof(T), true).MoveToPyObject();
         }
     }
 }


### PR DESCRIPTION

Fix ToPythonAs<> so that it always returns an explicit interface wrapper.

ToPythonAs opts into the converter's behavior that this fork doesn't use by default, but it is still valid behavior when ToPythonAs is used