### PR TITLE
add pep8 alias binding option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,3 +7,4 @@ Changes relative to pythonnet:
 * Revert of `#1240 <https://github.com/pythonnet/pythonnet/pull/1240>`_.
 * Opt-into explicit interface wrapping, `#19 <https://github.com/ansys/ansys-pythonnet/pull/19>`_. This opts into the behavior that became the default in #1240 if ToPythonAs<T> is explicitly used
 * Option to bind explicit interface implementations, `#23 <https://github.com/ansys/ansys-pythonnet/pull/23>`_. This provides a runtime option to expose C# explicit interface implementations to Python.
+* Option to bind pep8 aliases `#24 <https://github.com/ansys/ansys-pythonnet/pull/24>`_.

--- a/src/runtime/BindingOptions.cs
+++ b/src/runtime/BindingOptions.cs
@@ -9,6 +9,7 @@ namespace Python.Runtime
         private bool _SuppressDocs = false;
         private bool _SuppressOverloads = false;
         private bool _AllowExplicitInterfaceImplementation = false;
+        private bool _Pep8Aliases = false;
 
         //[ModuleProperty]
         public bool SuppressDocs
@@ -28,6 +29,12 @@ namespace Python.Runtime
         {
             get { return _AllowExplicitInterfaceImplementation; }
             set { _AllowExplicitInterfaceImplementation = value; }
+        }
+
+        public bool Pep8Aliases
+        {
+            get { return _Pep8Aliases; }
+            set { _Pep8Aliases = value; }
         }
     }
 

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -736,7 +736,6 @@ namespace Python.Test
         }
     }
 
-
     public class MethodTestSub : MethodTest
     {
         public MethodTestSub() : base()

--- a/src/testing/pep8test.cs
+++ b/src/testing/pep8test.cs
@@ -1,0 +1,16 @@
+namespace Python.Test
+{
+    public class Pep8Test
+    {
+        public string Foo() => "hello";
+
+        private int _bar = 1;
+        public int Bar
+        {
+            get { return _bar; }
+            set { _bar = value; }
+        }
+
+        public double BazPi = 3.14;
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_configure(config):
     python_test_module = clr.AddReference("Python.Test")
     configure_custom_binding_options(python_test_module)
 
-    launch_debugger()
+    #launch_debugger()
 
 
 def configure_custom_binding_options(python_test_module):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,14 +90,27 @@ def pytest_configure(config):
     python_test_module = clr.AddReference("Python.Test")
     configure_custom_binding_options(python_test_module)
 
+    launch_debugger()
+
 
 def configure_custom_binding_options(python_test_module):
     from Python.Runtime import BindingManager, BindingOptions
+    module_types = python_test_module.GetTypes()
+
     binding_options = BindingOptions()
     binding_options.AllowExplicitInterfaceImplementation = True
-    prop_test_3_type = [t for t in python_test_module.GetTypes() if "PropertyTest3" == t.Name][0]
-
+    prop_test_3_type = [t for t in module_types if "PropertyTest3" == t.Name][0]
     BindingManager.SetBindingOptions(prop_test_3_type, binding_options)
+
+    binding_options = BindingOptions()
+    binding_options.Pep8Aliases = True
+    method_test_pep8_type = [t for t in module_types if "Pep8Test" == t.Name][0]
+    BindingManager.SetBindingOptions(method_test_pep8_type, binding_options)
+
+
+def launch_debugger():
+    import System
+    System.Diagnostics.Debugger.Launch()
 
 
 def pytest_unconfigure(config):

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+"""Test CLR method support."""
+
+import System
+import pytest
+from Python.Test import Pep8Test
+
+def test_pep8_method():
+    """Test PEP8-styled alias of method."""
+    assert "hello" == Pep8Test().Foo()
+    assert "hello" == Pep8Test().foo()
+
+
+def test_pep8_property():
+    """Test PEP8-styled alias of property."""
+    pep8_test = Pep8Test()
+    assert 1 == pep8_test.Bar
+    pep8_test.Bar = 2
+    assert 2 == pep8_test.bar
+    pep8_test.bar = 3
+    assert 3 == pep8_test.bar
+
+
+def test_pep8_field():
+    """Test PEP8-styled alias of field."""
+    pep8_test = Pep8Test()
+    assert 3.14 == pep8_test.BazPi
+    assert 3.14 == pep8_test.baz_pi
+    pep8_test.baz_pi = 3.1415
+    assert 3.1415 == pep8_test.BazPi


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

C# naming conventions are different from python naming conventions. CamelCase is the usual convention for properties and methods in C#, while snake_case is preferred in python (pep8).

When using ansys-pythonnet to bind C# to python, python users will use the C# APIs with the C# conventions. This breaks expectations for python users.

This PR adds an option to enable pep8 aliases for python bindings, allowing python code to use pep8 even if the C# code does not.

